### PR TITLE
clockSettingsGui: call to addonHandler.initTranslation()

### DIFF
--- a/addon/globalPlugins/clock/clockSettingsGUI.py
+++ b/addon/globalPlugins/clock/clockSettingsGUI.py
@@ -14,7 +14,8 @@ import nvwave
 import gui
 import os
 import wx
-
+import addonHandler
+addonHandler.initTranslation()
 class clockSettingsDialog(gui.SettingsDialog):
 	title=_("Clock Settings")
 


### PR DESCRIPTION
In order to make all strings translatable using the locale catalogs included in the addon, addonHandler.initTranslation() must be called from every module which includes calls to the _() function. Configuration dialog should be localized now.