### PR TITLE
Fix bug that caused decode errors when trying to get day and week of year while using languages with non-ascii characters

### DIFF
--- a/addon/globalPlugins/clock/__init__.py
+++ b/addon/globalPlugins/clock/__init__.py
@@ -76,12 +76,14 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		self.clock.terminate()
 
 	def script_reportTimeAndDate(self, gesture):
+		now=datetime.now()
 		if scriptHandler.getLastScriptRepeatCount() == 0:
-			ui.message(datetime.now().strftime(config.conf["clockAndCalendar"]["timeDisplayFormat"]).decode("mbcs"))
+			msg=now.strftime(config.conf["clockAndCalendar"]["timeDisplayFormat"])
 		elif scriptHandler.getLastScriptRepeatCount() == 1:
-			ui.message(datetime.now().strftime(config.conf["clockAndCalendar"]["dateDisplayFormat"]).decode("mbcs"))
+			msg=now.strftime(config.conf["clockAndCalendar"]["dateDisplayFormat"])
 		else:
-			ui.message(datetime.now().strftime(_("Day %j, week %W of %Y.")).decode("mbcs"))
+			msg=_("Day {day}, week {week} of {year}").format(day=now.timetuple()[7], week=now.isocalendar()[1], year=now.year)
+		ui.message(msg)
 	script_reportTimeAndDate.__doc__=_("Speaks current time. If pressed twice quickly, speaks current date. If pressed thrice quickly, reports the current day and week number of the year.")
 
 	def getScript(self, gesture):

--- a/addon/globalPlugins/clock/__init__.py
+++ b/addon/globalPlugins/clock/__init__.py
@@ -21,6 +21,7 @@ import gettext
 import languageHandler
 import addonHandler
 addonHandler.initTranslation()
+import locale
 
 #Command layer environment.
 def finally_(func, final):
@@ -78,9 +79,9 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 	def script_reportTimeAndDate(self, gesture):
 		now=datetime.now()
 		if scriptHandler.getLastScriptRepeatCount() == 0:
-			msg=now.strftime(config.conf["clockAndCalendar"]["timeDisplayFormat"])
+			msg=now.strftime(config.conf["clockAndCalendar"]["timeDisplayFormat"]).decode(locale.getlocale()[1])
 		elif scriptHandler.getLastScriptRepeatCount() == 1:
-			msg=now.strftime(config.conf["clockAndCalendar"]["dateDisplayFormat"])
+			msg=now.strftime(config.conf["clockAndCalendar"]["dateDisplayFormat"]).decode(locale.getlocale()[1])
 		else:
 			msg=_("Day {day}, week {week} of {year}").format(day=now.timetuple()[7], week=now.isocalendar()[1], year=now.year)
 		ui.message(msg)

--- a/addon/globalPlugins/clock/clockSettingsGUI.py
+++ b/addon/globalPlugins/clock/clockSettingsGUI.py
@@ -13,6 +13,7 @@ import os
 import wx
 import addonHandler
 addonHandler.initTranslation()
+import locale
 
 class ClockSettingsPanel(gui.SettingsPanel):
 	# Translators: This is the label for the clock settings panel.
@@ -23,7 +24,7 @@ class ClockSettingsPanel(gui.SettingsPanel):
 		# Translators: This is the label for a combo box in the Clock settings dialog.
 		self._timeDisplayFormatChoice = clockSettingsGuiHelper.addLabeledControl(_("&Time display format:"), wx.Choice, choices=[datetime.now().strftime(x) for x in formats.timeDisplayFormats])
 		# Translators: This is the label for a combo box in the Clock settings dialog.
-		self._dateDisplayFormatChoice = clockSettingsGuiHelper.addLabeledControl(_("&Date display format:"), wx.Choice, choices=[datetime.now().strftime(x) for x in formats.dateDisplayFormats])
+		self._dateDisplayFormatChoice = clockSettingsGuiHelper.addLabeledControl(_("&Date display format:"), wx.Choice, choices=[datetime.now().strftime(x).decode(locale.getlocale()[1]) for x in formats.dateDisplayFormats])
 		# Translators: This is the label for a checkbox in the Clock settings dialog.
 		self.input24HourFormatCheckBox = clockSettingsGuiHelper.addItem(wx.CheckBox(self, label=_("Input in &24-hour format")))
 		autoAnnounceChoices=(_("off"), _("every 10 minutes"), _("every 15 minutes"), _("every 30 minutes"), _("every hour"))

--- a/addon/locale/es/LC_MESSAGES/nvda.po
+++ b/addon/locale/es/LC_MESSAGES/nvda.po
@@ -2,15 +2,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Clock 1.0dev\n"
 "Report-Msgid-Bugs-To: 'nvda-translations@freelists.org'\n"
-"POT-Creation-Date: 2018-03-20 14:11+0100\n"
-"PO-Revision-Date: 2018-05-11 21:05+0100\n"
-"Last-Translator: Iván Novegil <ivan.novegil.cancelas@gmail.com>\n"
+"POT-Creation-Date: 2018-10-30 12:46+0100\n"
+"PO-Revision-Date: 2018-10-30 12:47+0100\n"
+"Last-Translator: José Manuel Delicado <jmdaweb@hotmail.com>\n"
 "Language-Team: Rémy Ruiz <remyruiz@gmail.com>\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 1.6.11\n"
+"X-Generator: Poedit 2.2\n"
 "X-Poedit-Basepath: .\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Poedit-SourceCharset: UTF-8\n"
@@ -20,47 +20,47 @@ msgstr ""
 "X-Poedit-SearchPath-3: C:/Programmi/NVDA/userConfig/addons/Weather Plus/"
 "globalPlugins/weather\n"
 
-#: addon\globalPlugins\clock\__init__.py:49
+#: addon\globalPlugins\clock\__init__.py:47
 #, python-format
 msgid "%d hour, "
 msgstr "%d hora, "
 
-#: addon\globalPlugins\clock\__init__.py:51
+#: addon\globalPlugins\clock\__init__.py:49
 #, python-format
 msgid "%d hours, "
 msgstr "%d horas, "
 
-#: addon\globalPlugins\clock\__init__.py:53
+#: addon\globalPlugins\clock\__init__.py:51
 #, python-format
 msgid "%d minute, "
 msgstr "%d minuto, "
 
-#: addon\globalPlugins\clock\__init__.py:55
+#: addon\globalPlugins\clock\__init__.py:53
 #, python-format
 msgid "%d minutes, "
 msgstr "%d minutos, "
 
-#: addon\globalPlugins\clock\__init__.py:57
+#: addon\globalPlugins\clock\__init__.py:55
 #, python-format
 msgid "%s second"
 msgstr "%s segundo"
 
-#: addon\globalPlugins\clock\__init__.py:59
+#: addon\globalPlugins\clock\__init__.py:57
 #, python-format
 msgid "%s seconds"
 msgstr "%s segundos"
 
-#: addon\globalPlugins\clock\__init__.py:67
-msgid "&Clock Settings..."
-msgstr "Opciones del &Reloj..."
+#. Translators: Script category for Clock addon commands in input gestures dialog.
+#. Translators: This is the label for the clock settings panel.
+#. Translators: Summary for this add-on to be shown on installation and add-on information.
+#: addon\globalPlugins\clock\__init__.py:62
+#: addon\globalPlugins\clock\clockSettingsGUI.py:19 buildVars.py:11
+msgid "Clock"
+msgstr "Clock"
 
-#: addon\globalPlugins\clock\__init__.py:67
-msgid "Clock and calendar setup"
-msgstr "Configuración del reloj y del calendario"
-
-#: addon\globalPlugins\clock\__init__.py:86
-msgid "Day %j, week %W of %Y."
-msgstr "Día %j, semana %W de %Y."
+#: addon\globalPlugins\clock\__init__.py:85
+msgid "Day {day}, week {week} of {year}"
+msgstr "Día {day}, semana {week} de {year}"
 
 #: addon\globalPlugins\clock\__init__.py:87
 msgid ""
@@ -133,159 +133,161 @@ msgstr ""
 msgid "Lists available commands in clock command layer."
 msgstr "Enumera las órdenes disponibles en la órden en capa del reloj."
 
-#: addon\globalPlugins\clock\clockSettingsGUI.py:20
-msgid "Clock Settings"
-msgstr "Opciones del Reloj"
-
-#: addon\globalPlugins\clock\clockSettingsGUI.py:29
+#. Translators: This is the label for a combo box in the Clock settings dialog.
+#: addon\globalPlugins\clock\clockSettingsGUI.py:24
 msgid "&Time display format:"
 msgstr "Formato de visualización de la &hora:"
 
-#: addon\globalPlugins\clock\clockSettingsGUI.py:37
+#. Translators: This is the label for a combo box in the Clock settings dialog.
+#: addon\globalPlugins\clock\clockSettingsGUI.py:26
 msgid "&Date display format:"
 msgstr "Formato de visualización de la &fecha:"
 
-#. check box for 24-hour input
-#: addon\globalPlugins\clock\clockSettingsGUI.py:44
+#. Translators: This is the label for a checkbox in the Clock settings dialog.
+#: addon\globalPlugins\clock\clockSettingsGUI.py:28
 msgid "Input in &24-hour format"
 msgstr "Entrada al formato de &24 horas"
 
-#: addon\globalPlugins\clock\clockSettingsGUI.py:48
-msgid "Auto announce &interval:"
-msgstr "&Intervalo del anunciado automático:"
-
-#: addon\globalPlugins\clock\clockSettingsGUI.py:50
+#: addon\globalPlugins\clock\clockSettingsGUI.py:29
 msgid "off"
 msgstr "desactivado"
 
-#: addon\globalPlugins\clock\clockSettingsGUI.py:50
+#: addon\globalPlugins\clock\clockSettingsGUI.py:29
 msgid "every 10 minutes"
 msgstr "cada 10 minutos"
 
-#: addon\globalPlugins\clock\clockSettingsGUI.py:50
+#: addon\globalPlugins\clock\clockSettingsGUI.py:29
 msgid "every 15 minutes"
 msgstr "cada 15 minutos"
 
-#: addon\globalPlugins\clock\clockSettingsGUI.py:50
+#: addon\globalPlugins\clock\clockSettingsGUI.py:29
 msgid "every 30 minutes"
 msgstr "cada 30 minutos"
 
-#: addon\globalPlugins\clock\clockSettingsGUI.py:50
+#: addon\globalPlugins\clock\clockSettingsGUI.py:29
 msgid "every hour"
 msgstr "cada hora"
 
-#: addon\globalPlugins\clock\clockSettingsGUI.py:58
-msgid "Time &announcement:"
-msgstr "&Anunciado de la hora:"
+#. Translators: This is the label for a combo box in the Clock settings dialog.
+#: addon\globalPlugins\clock\clockSettingsGUI.py:31
+msgid "Auto announce &interval:"
+msgstr "&Intervalo del anunciado automático:"
 
-#: addon\globalPlugins\clock\clockSettingsGUI.py:60
+#: addon\globalPlugins\clock\clockSettingsGUI.py:33
 msgid "speech and sound"
 msgstr "voz y sonido"
 
-#: addon\globalPlugins\clock\clockSettingsGUI.py:60
+#: addon\globalPlugins\clock\clockSettingsGUI.py:33
 msgid "speech only"
 msgstr "sólo voz"
 
-#: addon\globalPlugins\clock\clockSettingsGUI.py:60
+#: addon\globalPlugins\clock\clockSettingsGUI.py:33
 msgid "sound only"
 msgstr "sólo sonido"
 
-#: addon\globalPlugins\clock\clockSettingsGUI.py:67
+#. Translators: This is the label for a combo box in the Clock settings dialog.
+#: addon\globalPlugins\clock\clockSettingsGUI.py:35
+msgid "Time &announcement:"
+msgstr "&Anunciado de la hora:"
+
+#. Translators: This is the label for a combo box in the Clock settings dialog.
+#: addon\globalPlugins\clock\clockSettingsGUI.py:37
 msgid "Clock chime &sound:"
 msgstr "&Sonido de campana de reloj:"
 
-#. check box for quiet hours
-#: addon\globalPlugins\clock\clockSettingsGUI.py:79
+#. Translators: This is the label for a checkbox in the Clock settings dialog.
+#: addon\globalPlugins\clock\clockSettingsGUI.py:41
 msgid "&Quiet hours"
 msgstr "&Horas silenciosas"
 
-#: addon\globalPlugins\clock\clockSettingsGUI.py:85
+#. Translators: This is the label for an edit field in the Clock settings dialog.
+#: addon\globalPlugins\clock\clockSettingsGUI.py:44
 msgid "Quiet hours start time:"
 msgstr "Inicio de horas silenciosas:"
 
-#: addon\globalPlugins\clock\clockSettingsGUI.py:93
+#. Translators: This is the label for an edit field in the Clock settings dialog.
+#: addon\globalPlugins\clock\clockSettingsGUI.py:46
 msgid "Quiet hours end time:"
 msgstr "Fin de horas silenciosas:"
 
-#: addon\globalPlugins\clock\formats.py:13
+#: addon\globalPlugins\clock\formats.py:10
 msgid "It's %H hours and %M minutes"
 msgstr "Son %H horas y %M minutos"
 
-#: addon\globalPlugins\clock\formats.py:14
+#: addon\globalPlugins\clock\formats.py:11
 msgid "It's %H hours, %M minutes and %S seconds"
 msgstr "Son %H horas, %M minutos y %S segundos"
 
-#: addon\globalPlugins\clock\formats.py:15
+#: addon\globalPlugins\clock\formats.py:12
 msgid "%H hours, %M minutes"
 msgstr "%H horas, %M minutos"
 
-#: addon\globalPlugins\clock\formats.py:16
+#: addon\globalPlugins\clock\formats.py:13
 msgid "%H hours, %M minutes, %S seconds"
 msgstr "%H horas, %M minutos, %S segundos"
 
-#: addon\globalPlugins\clock\formats.py:17
+#: addon\globalPlugins\clock\formats.py:14
 msgid "%H h, %M min"
 msgstr "%H h, %M min"
 
-#: addon\globalPlugins\clock\formats.py:18
+#: addon\globalPlugins\clock\formats.py:15
 msgid "%H h, %M min, %S sec"
 msgstr "%H h, %M min, %S seg"
 
-#: addon\globalPlugins\clock\formats.py:19
+#: addon\globalPlugins\clock\formats.py:16
 msgid "%H:%M:%S"
 msgstr "%H:%M:%S"
 
-#: addon\globalPlugins\clock\formats.py:20
+#: addon\globalPlugins\clock\formats.py:17
 msgid "%H:%M"
 msgstr "%H:%M"
 
-#: addon\globalPlugins\clock\formats.py:21
+#: addon\globalPlugins\clock\formats.py:18
 msgid "It's %I:%M %p"
 msgstr "Son %I:%M %p"
 
-#: addon\globalPlugins\clock\formats.py:22
+#: addon\globalPlugins\clock\formats.py:19
 msgid "It's %I:%M:%S %p"
 msgstr "Son %I:%M:%S %p"
 
-#: addon\globalPlugins\clock\formats.py:23
+#: addon\globalPlugins\clock\formats.py:20
 msgid "%I:%M %p"
 msgstr "%I:%M %p"
 
-#: addon\globalPlugins\clock\formats.py:24
+#: addon\globalPlugins\clock\formats.py:21
 msgid "%I:%M:%S %p"
 msgstr "%I:%M:%S %p"
 
-#: addon\globalPlugins\clock\formats.py:28
+#: addon\globalPlugins\clock\formats.py:25
 msgid "%A, %B %d, %Y"
 msgstr "%A, %B %d, %Y"
 
-#: addon\globalPlugins\clock\formats.py:29
+#: addon\globalPlugins\clock\formats.py:26
 msgid "%Y-%d-%m"
 msgstr "%Y-%d-%m"
 
-#: addon\globalPlugins\clock\formats.py:30
+#: addon\globalPlugins\clock\formats.py:27
+msgid "%Y-%m-%d"
+msgstr "%d-%m-%Y"
+
+#: addon\globalPlugins\clock\formats.py:28
 msgid "%d-%m-%Y"
 msgstr "%d-%m-%Y"
 
-#: addon\globalPlugins\clock\formats.py:31
+#: addon\globalPlugins\clock\formats.py:29
 msgid "%m-%d-%Y"
 msgstr "%m-%d-%Y"
 
-#: addon\globalPlugins\clock\formats.py:32
+#: addon\globalPlugins\clock\formats.py:30
 msgid "%m/%d/%Y"
 msgstr "%m/%d/%Y"
 
-#: addon\globalPlugins\clock\formats.py:33
+#: addon\globalPlugins\clock\formats.py:31
 msgid "%d/%m/%Y"
 msgstr "%d/%m/%Y"
 
-#. Translators: Summary for this add-on to be shown on installation and add-on information.
-#: buildVars.py:14
-msgid "Clock"
-msgstr "Clock"
-
 #. Translators: Long description to be shown for this add-on on add-on information from add-ons manager
-#: buildVars.py:16
+#: buildVars.py:13
 msgid ""
 "An advanced clock and calendar for NVDA.\n"
 "Press NVDA + F12 for current time, press it twice for current date, or press "
@@ -297,3 +299,15 @@ msgstr ""
 "pulsar tres veces para obtener el día y la semana del año.\n"
 "Para otras instrucciones, pulsar el botón Ayuda del Complemento en el "
 "Administrador de Complementos."
+
+#~ msgid "&Clock Settings..."
+#~ msgstr "Opciones del &Reloj..."
+
+#~ msgid "Clock and calendar setup"
+#~ msgstr "Configuración del reloj y del calendario"
+
+#~ msgid "Day %j, week %W of %Y."
+#~ msgstr "Día %j, semana %W de %Y."
+
+#~ msgid "Clock Settings"
+#~ msgstr "Opciones del Reloj"

--- a/buildVars.py
+++ b/buildVars.py
@@ -14,7 +14,7 @@ addon_info = {
 Press NVDA + F12 for current time, press it twice for current date, or press it thrice to get current day and week of the year.
 For other instructions, press Add-on help button in add-ons manager."""),
 	"addon_version" : "18.06dev",
-	"addon_author" : u"Hrvoje Katić <hrvojekatic@gmail.com>",
+	"addon_author" : "Hrvoje Katic <hrvojekatic@gmail.com>",
 	"addon_url" : "https://github.com/hkatic/clock",
 	"addon_docFileName" : "readme.html",
 }


### PR DESCRIPTION
The following changes where made:
* Python 3 transition: removed U character from unicode string in buildVars.py for the author parameter.
Replaced the ending C in the name with an ASCII character.
* Updated spanish translation.
* Fixed a bug when announcing the day and the week of the year. strftime function is no longer used in this
case, and the message is formated manually. This adds compatibility with languages with non-ASCII characters. Thanks to all the people who have reported this through the spanish community.

If any problem don't hesitate to comment.