### PR TITLE
Report one more remaining day on leap years

### DIFF
--- a/addon/globalPlugins/clock/__init__.py
+++ b/addon/globalPlugins/clock/__init__.py
@@ -131,6 +131,8 @@ def getDayAndWeekOfYear (date):
 	if curYear == gregYear:
 		# It's a Gregorian year.
 		total = convertdate.gregorian.YEAR_DAYS
+		if convertdate.gregorian.isleap(gregYear):
+			total+=1
 		nDayOfYear = int (now.timetuple()[7])
 	else:
 		# It's a Hijri year.


### PR DESCRIPTION
A spanish-speaking user has reported through one of our community lists that, when pressing NVDA+F12 thrice on January 2nd, 2020, the addon said "363 days remaining" while, as 2020 is a leap year, it should say "364". Link to the original post: https://groups.google.com/d/msg/nvda-es/z26JdoWGJGw/qy4CT90YCAAJ
This issue has been succesfully reproduced.

This PR adds to __init__.py a solution to add one more day to the total when the year is leap (calendar.isleap). For eficiency purposes the function has been taken directly from convertdate.gregorian instead of directly importing it from the calendar module.

This code has been tested with Python 2 ONLY.

If any problem don't hesitate to comment.