### PR TITLE
Fixed an issue occurring when translated time formats are not unique.

### DIFF
--- a/addon/globalPlugins/clock/__init__.py
+++ b/addon/globalPlugins/clock/__init__.py
@@ -12,8 +12,10 @@ import globalPluginHandler
 import gui
 from . import paths
 import scriptHandler
+from logHandler import log
 import ui
 from . import formats
+from collections import Counter
 import nvwave
 from . import clockHandler
 from . import stopwatchHandler
@@ -152,6 +154,17 @@ def getDayAndWeekOfYear(date: str) -> Tuple[int, ...]:
 	return (nDayOfYear, nWeekOfYear, curYear, daysRemaining)
 
 
+def checkLocalTimeFormats():
+	"""A function that checks that each localized time format is unique.
+	In case two or more identical time formats are found, a warning is logged, to give translators the
+	opportunity to improve their translations by translating uniquely each time format.
+	"""
+	fmtCounter = Counter(formats.timeFormats)
+	for (fmt, nbOccurrences) in fmtCounter.items():
+		if nbOccurrences > 1:
+			log.debugWarning(f"The format '{fmt}' appears {nbOccurrences} times for the current localization.")
+
+
 class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 
 	# Translators: Script category for Clock addon commands in input gestures dialog.
@@ -163,6 +176,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		super(globalPluginHandler.GlobalPlugin, self).__init__()
 		if globalVars.appArgs.secure or config.isAppX:
 			return
+		checkLocalTimeFormats()
 		gui.NVDASettingsDialog.categoryClasses.append(ClockSettingsPanel)
 		self.toolsMenu = gui.mainFrame.sysTrayIcon.toolsMenu
 		self.alarmSettings = self.toolsMenu.Append(

--- a/addon/globalPlugins/clock/formats.py
+++ b/addon/globalPlugins/clock/formats.py
@@ -3,7 +3,6 @@
 # Author: Hrvoje Katich and contributors
 # Copyright 2013-2021, released under GPL.
 
-import collections
 import winKernel
 import re
 import addonHandler
@@ -11,8 +10,7 @@ addonHandler.initTranslation()
 
 # A regular expression to match and facilitate translation for words that are
 # not part of the formatting symbols.
-# Ignore Flake8 W605: invalid escape sequence (\w)
-ptrn = "(\w+'?\w*|\$+[hmst]{1,2})"  # NOQA: W605
+ptrn = r"(\w+'?\w*|\$+[hmst]{1,2})"
 rgx = re.compile(ptrn, re.U | re.I)
 
 
@@ -55,27 +53,27 @@ def timeMarker():
 
 
 timeFormats = (
-	# Translators: A time formating.
+	# Translators: A time formating (should be different from other time formattings)
 	_("It's {hours} o'clock and {minutes} minutes").format(hours="$$H", minutes="$$m"),
-	# Translators: A time formating.
+	# Translators: A time formating (should be different from other time formattings)
 	_("It's {hours} o'clock, {minutes} minutes and {seconds} seconds").format(
 		hours="$$H", minutes="$$m", seconds="$$s"
 	),
-	# Translators: A time formating.
+	# Translators: A time formating (should be different from other time formattings)
 	_("{hours} o'clock, {minutes} minutes").format(hours="$$H", minutes="$$mm"),
-	# Translators: A time formating.
+	# Translators: A time formating (should be different from other time formattings)
 	_("{hours} o'clock, {minutes} minutes, {seconds} seconds").format(
 		hours="$$H", minutes="$$mm", seconds="$$ss"
 	),
-	# Translators: A time formating.
+	# Translators: A time formating (should be different from other time formattings)
 	_("It's {minutes} past {hours}").format(minutes="$$m", hours="$$H"),
-	# Translators: A time formating.
+	# Translators: A time formating (should be different from other time formattings)
 	_("{hours} h {minutes} min").format(hours="$$H", minutes="$$m"),
-	# Translators: A time formating.
+	# Translators: A time formating (should be different from other time formattings)
 	_("{hours} h, {minutes} min, {seconds} sec").format(hours="$$H", minutes="$$m", seconds="$$s"),
-	# Translators: A time formating.
+	# Translators: A time formating (should be different from other time formattings)
 	_("It's {hours}:{minutes}").format(hours="$$H", minutes="$$m"),
-	# Translators: A time formating.
+	# Translators: A time formating (should be different from other time formattings)
 	_("It's {hours}:{minutes}:{seconds}").format(hours="$$HH", minutes="$$mm", seconds="$$ss"),
 	"$$hh:$$mm:$$ss $$tt",
 	"$$hh:$$m $$tt",
@@ -89,11 +87,7 @@ timeFormats = (
 	"$$H:$$m",
 )
 
-timeFormatsDic = collections.OrderedDict()
-for fmt in timeFormats:
-	timeFormatsDic[fmt] = winKernel.GetTimeFormatEx(None, None, None, rgx.sub(repl, fmt))
-
-timeDisplayFormats = list(timeFormatsDic.values())
+timeDisplayFormats = [winKernel.GetTimeFormatEx(None, None, None, rgx.sub(repl, fmt)) for fmt in timeFormats]
 
 dateFormats = (
 	"dddd, MMMM dd, yyyy",
@@ -108,8 +102,4 @@ dateFormats = (
 	"dd/MM/yyyy"
 )
 
-dateFormatsDic = collections.OrderedDict()
-for fmt in dateFormats:
-	dateFormatsDic[fmt] = winKernel.GetDateFormatEx(None, None, None, fmt)
-
-dateDisplayFormats = list(dateFormatsDic.values())
+dateDisplayFormats = [winKernel.GetDateFormatEx(None, None, None, fmt) for fmt in dateFormats]


### PR DESCRIPTION
## Issue
### Steps to reproduce
* Run NVDA in French (maybe other languages have the same issue)
* In the options, select the penultimate choice in the time display formats list ("16:45:35") and validate
* Press NVDA+F12
### Actual result
NVDA reports "16:45" (without the seconds)
### Expected result
NVDA reports "16:45:35"

## Cause of the issue
In the French .po file, two time formats have the same translation:
```
msgid "It's {hours} o'clock and {minutes} minutes"
msgstr "Il est {hours} heures et {minutes} minutes"
```
and
```
msgid "It's {minutes} past {hours}"
msgstr "Il est {hours} heures et {minutes} minutes"
```

It's because the formulation "It's {minutes} past {hours}" has no idiomatic equivalent in French.

Having two identical formats leads to have one less entry in the timeFormatsDic and thus an index shift.

## How the issue has been fixed
* Do not use dic anymore for time formats, only lists.
  This leads to two identical items in the choice list but no index shift
* While at it, I have also removed the dic for date formats, even if no duplicate issue could arise since they are not translated
* Since having two identical items in the choice list is not desirable from a UX point of view, a warning is issued in the log in case formats localizations are not unique.
* I have also updated the translator comments for time formats to indicate clearly that duplicate time formats are not desirable

### Additional changes

Unrelated, but I have removed and fixed a #noqa, making the regexp string a raw string.
