### PR TITLE
Add on-demand mode support

### DIFF
--- a/addon/globalPlugins/clock/__init__.py
+++ b/addon/globalPlugins/clock/__init__.py
@@ -32,6 +32,8 @@ sys.path.remove(sys.path[-1])
 import time
 from winKernel import GetTimeFormatEx, GetDateFormatEx
 from configobj.validate import VdtTypeError
+from functools import wraps
+from .speechOnDemand import getSpeechOnDemandParameter, executeWithSpeakOnDemand
 
 import addonHandler
 addonHandler.initTranslation()
@@ -53,6 +55,9 @@ confspec = {
 	'quietHoursEndTime': 'string(default="")',
 }
 config.conf.spec["clockAndCalendar"] = confspec
+
+# Define speakOnDemand parameter for all scripts needing it
+speakOnDemand = getSpeechOnDemandParameter()
 
 
 def secondsToString(seconds: float) -> str:
@@ -251,7 +256,8 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			"the current year and the days remaining before the end of the year."
 		),
 		category=globalCommands.SCRCAT_SYSTEM,
-		gesture="kb:NVDA+f12"
+		gesture="kb:NVDA+f12",
+		**speakOnDemand,
 	)
 	def script_reportTimeAndDate(self, gesture):
 		now = datetime.now()
@@ -277,10 +283,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 	globalCommands.commands.script_dateTime.__func__.__doc__ = ""
 
 	def getScript(self, gesture):
-		if (
-			not hasattr(self, "clockLayerModeActive")
-			or (hasattr(self, "clockLayerModeActive") and not self.clockLayerModeActive)
-		):
+		if not self.clockLayerModeActive:
 			return globalPluginHandler.GlobalPlugin.getScript(self, gesture)
 		script = globalPluginHandler.GlobalPlugin.getScript(self, gesture)
 		if not script:
@@ -288,7 +291,10 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		self.layeredScriptToRun = next(
 			(x[1] for x in self._clockLayerGestures if x[0] == gesture.mainKeyName), None
 		)
-		return self.runAndFinish
+		@wraps(self.layeredScriptToRun)
+		def wrappedScript(*args, **kw):
+			return self.runAndFinish(*args, **kw)
+		return wrappedScript
 
 	def runAndFinish(self, gesture):
 		if self.layeredScriptToRun is not None:
@@ -341,14 +347,16 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 
 	@scriptHandler.script(
 		# Translators: Message presented in input help mode.
-		description=_("Speaks current stopwatch or count-down timer.")
+		description=_("Speaks current stopwatch or count-down timer."),
+		**speakOnDemand,
 	)
 	def script_timeDisplay(self, gesture):
 		ui.message(secondsToString(self.stopwatch.elapsedTime()))
 
 	@scriptHandler.script(
 		# Translators: Message presented in input help mode.
-		description=_("Gives the remaining and elapsed time before the next alarm.")
+		description=_("Gives the remaining and elapsed time before the next alarm."),
+		**speakOnDemand,
 	)
 	def script_alarmInfo(self, gesture):
 		if alarmHandler.run and alarmHandler.run.is_alive():
@@ -388,14 +396,16 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 
 	@scriptHandler.script(
 		# Translators: Message presented in input help mode.
-		description=_("Lists available commands in clock command layer.")
+		description=_("Lists available commands in clock command layer."),
+		**speakOnDemand,
 	)
 	def script_getHelp(self, gesture):
 		ui.message("\n".join(x[0] + " : " + x[1].__doc__ if x[0] != "space" else skipTranslation.translate(x[0]) + " : " + x[1].__doc__ for x in self._clockLayerGestures))  # NOQA: E501
 
 	@scriptHandler.script(
 		# Translators: Message presented in input help mode.
-		description=_("Allows to check the next alarm. If pressed twice, cancels it.")
+		description=_("Allows to check the next alarm. If pressed twice, cancels it."),
+		**speakOnDemand,
 	)
 	def script_checkOrCancelAlarm(self, gestures):
 		if alarmHandler.run and alarmHandler.run.is_alive():

--- a/addon/globalPlugins/clock/speechOnDemand.py
+++ b/addon/globalPlugins/clock/speechOnDemand.py
@@ -1,0 +1,63 @@
+# Copyright (C) 2023-2024 Cyrille Bougot
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+"""A module to manage speak on-demand feature support for add-ons.
+Compatible with NVDA 2019.3 and above.
+"""
+
+import threading
+
+import speech
+import core
+
+
+def isSpeechOnDemandFeatureAvailable():
+	"""Indicates if the speech on-demand feature is available in the current version of NVDA.
+	"""
+
+	try:
+		# NVDA >= 2024.1
+		speech.SpeechMode.onDemand
+		return True
+	except AttributeError:
+		# NVDA <= 2023.3
+		return False
+
+
+def getSpeechOnDemandParameter():
+	"""Returns a dictionary containing the speakOnDemand parameter and its True value for NVDA versions where
+	this feature exists; returns an empty dictionary otherwise.
+	Use `**getSpeechOnDemandParameter()` in script decorator's parameters to define `speakOnDemand=True` only
+	for NVDA versions where this feature is supported.
+	"""
+
+	if isSpeechOnDemandFeatureAvailable():
+		# Define on-demand parameter only if the feature is available.
+		return {'speakOnDemand': True}
+	else:
+		return {}
+
+
+def executeWithSpeakOnDemand(f, *args, **kwargs):
+	"""Allows to execute a function forcing the on-demand mode for its execution.
+	This may be useful for a functions that is scheduled by an on-demand script
+	to be run after the script execution has finished, e.g. using `core.callLater`.
+	This function should only be called from the main thread.
+
+	Parameters:
+	f: function to execute.
+	args: unnamed arguments to pass to the function.
+	kwargs: keyword arguments to pass to the function.
+	"""
+
+	if threading.get_ident() != core.mainThreadId:
+		raise RuntimeError('This function should only be executed from the main thread.')
+
+	if not isSpeechOnDemandFeatureAvailable() or speech.getState().speechMode != speech.SpeechMode.onDemand:
+		return f(*args, **kwargs)
+	try:
+		speech.setSpeechMode(speech.SpeechMode.talk)
+		return f(*args, **kwargs)
+	finally:
+		speech.setSpeechMode(speech.SpeechMode.onDemand)


### PR DESCRIPTION
Issue discussed [here](https://nvda.groups.io/g/nvda/topic/time_and_date_is_not_reported/106233622) on NVDA mailing list.

### Issue
On-demand mode is not supported by this add-on.

### Solution
Added on-demand support.

### Test
Tested `NVDA+f12` as well as appropriate layered commands in normal mode and in on-demand mode.
