### PR TITLE
NVDA 2026.1support

### DIFF
--- a/addon/globalPlugins/clock/__init__.py
+++ b/addon/globalPlugins/clock/__init__.py
@@ -263,16 +263,16 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		now = datetime.now()
 		if scriptHandler.getLastScriptRepeatCount() == 0:
 			msg = GetTimeFormatEx(
-				None, None, now, formats.rgx.sub(
+				None, 0, now, formats.rgx.sub(
 					formats.repl, formats.timeFormats[config.conf['clockAndCalendar']['timeDisplayFormat']]
 				)
 			)
 		elif scriptHandler.getLastScriptRepeatCount() == 1:
 			msg = GetDateFormatEx(
-				None, None, None, formats.dateFormats[config.conf['clockAndCalendar']['dateDisplayFormat']]
+				None, 0, None, formats.dateFormats[config.conf['clockAndCalendar']['dateDisplayFormat']]
 			)
 		else:
-			informations = getDayAndWeekOfYear(GetDateFormatEx(None, None, None, "yyyy/M/d"))
+			informations = getDayAndWeekOfYear(GetDateFormatEx(None, 0, None, "yyyy/M/d"))
 			msg = _(
 				"Day {day}, week {week} of {year}, remaining days {remain}."
 			).format(day=informations[0], week=informations[1], year=informations[2], remain=informations[3])

--- a/addon/globalPlugins/clock/formats.py
+++ b/addon/globalPlugins/clock/formats.py
@@ -109,7 +109,7 @@ timeDisplayFormats = [(
 	_('{fmt} (24-hour format)') if is24HourFormat(fmt) else
 	# Translators: A way to display 12-hour formats in the time display formats list in the settings panel.
 	_('{fmt} (12-hour format)')
-).format(fmt=winKernel.GetTimeFormatEx(None, None, DT_EXAMPLE, rgx.sub(repl, fmt))) for fmt in timeFormats]
+).format(fmt=winKernel.GetTimeFormatEx(None, 0, DT_EXAMPLE, rgx.sub(repl, fmt))) for fmt in timeFormats]
 
 dateFormats = (
 	"dddd, MMMM dd, yyyy",
@@ -124,4 +124,4 @@ dateFormats = (
 	"dd/MM/yyyy"
 )
 
-dateDisplayFormats = [winKernel.GetDateFormatEx(None, None, None, fmt) for fmt in dateFormats]
+dateDisplayFormats = [winKernel.GetDateFormatEx(None, 0, None, fmt) for fmt in dateFormats]

--- a/buildVars.py
+++ b/buildVars.py
@@ -27,9 +27,9 @@ addon_info = {
 NVDA+F12, get current time.
 NVDA+F12 pressed twice quickly, get current date.
 NVDA+F12 pressed three times quickly, reports the current day, the week number, the current year and the remaining days before the end of the year.
-For other instructions, press Add-on help button in add-ons manager."""),
+For other instructions, press  actions button in add-on store, then go to help."""),
 	# version
-	"addon_version": "20250707.1.0",
+	"addon_version": "20251004.1.0",
 	# Author(s)
 	"addon_author" : "Hrvoje Katic <hrvojekatic@gmail.com>, Abdel <abdelkrim.bensaid@gmail.com>",
 	# URL for the add-on documentation support
@@ -39,7 +39,7 @@ For other instructions, press Add-on help button in add-ons manager."""),
 	# Minimum NVDA version supported (e.g. "2018.3.0", minor version is optional)
 	"addon_minimumNVDAVersion" : "2019.3",
 	# Last NVDA version supported/tested (e.g. "2018.4.0", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion": "2025.1",
+	"addon_lastTestedNVDAVersion": "2026.1",
 	# Add-on update channel (default is None, denoting stable releases,
 	# and for development releases, use "dev".)
 	# Do not change unless you know what you are doing!

--- a/buildVars.py
+++ b/buildVars.py
@@ -1,50 +1,57 @@
-# -*- coding: UTF-8 -*-
-
 # Build customizations
 # Change this file instead of sconstruct or manifest files, whenever possible.
 
+from site_scons.site_tools.NVDATool.typings import AddonInfo, BrailleTables, SymbolDictionaries
 
 # Since some strings in `addon_info` are translatable,
 # we need to include them in the .po files.
 # Gettext recognizes only strings given as parameters to the `_` function.
-# To avoid initializing translations in this module we simply roll our own "fake" `_` function
+# To avoid initializing translations in this module we simply import a "fake" `_` function
 # which returns whatever is given to it as an argument.
-def _(arg):
-	return arg
+from site_scons.site_tools.NVDATool.utils import _
 
 
 # Add-on information variables
-addon_info = {
+addon_info = AddonInfo(
 	# add-on Name/identifier, internal for NVDA
-	"addon_name" : "clock",
-	# Add-on summary, usually the user visible name of the addon.
-	# Translators: Summary for this add-on
-	# to be shown on installation and add-on information found in Add-ons Manager.
-	"addon_summary" : _("Clock"),
+	addon_name="clock",
+	# Add-on summary/title, usually the user visible name of the add-on
+	# Translators: Summary/title for this add-on
+	# to be shown on installation and add-on information found in add-on store
+	addon_summary=_("Clock"),
 	# Add-on description
-	# Translators: Long description to be shown for this add-on on add-on information from add-ons manager
-	"addon_description" : _("""An advanced clock and calendar for NVDA.
+	# Translators: Long description to be shown for this add-on on add-on information from add-on store
+	addon_description=_("""An advanced clock and calendar for NVDA.
 NVDA+F12, get current time.
 NVDA+F12 pressed twice quickly, get current date.
 NVDA+F12 pressed three times quickly, reports the current day, the week number, the current year and the remaining days before the end of the year.
 For other instructions, press  actions button in add-on store, then go to help."""),
 	# version
-	"addon_version": "20251004.1.0",
+	addon_version="20251005.1.0",
+	# Brief changelog for this version
+	# Translators: what's new content for the add-on version to be shown in the add-on store
+	addon_changelog=_("""added NVDA 2026.1 compatibility """),
 	# Author(s)
-	"addon_author" : "Hrvoje Katic <hrvojekatic@gmail.com>, Abdel <abdelkrim.bensaid@gmail.com>",
+	addon_author="Hrvoje Katic <hrvojekatic@gmail.com>, Abdel <abdelkrim.bensaid@gmail.com>",
 	# URL for the add-on documentation support
-	"addon_url" : "https://github.com/hkatic/clock",
+	addon_url="https://github.com/hkatic/clock",
+	# URL for the add-on repository where the source code can be found
+	addon_sourceURL="https://github.com/hkatic/clock",
 	# Documentation file name
-	"addon_docFileName": "readme.html",
-	# Minimum NVDA version supported (e.g. "2018.3.0", minor version is optional)
-	"addon_minimumNVDAVersion" : "2019.3",
-	# Last NVDA version supported/tested (e.g. "2018.4.0", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion": "2026.1",
+	addon_docFileName="readme.html",
+	# Minimum NVDA version supported (e.g. "2019.3.0", minor version is optional)
+	addon_minimumNVDAVersion="2019.3",
+	# Last NVDA version supported/tested (e.g. "2024.4.0", ideally more recent than minimum version)
+	addon_lastTestedNVDAVersion="2026.1",
 	# Add-on update channel (default is None, denoting stable releases,
 	# and for development releases, use "dev".)
 	# Do not change unless you know what you are doing!
-	"addon_updateChannel": None,
-}
+	addon_updateChannel=None,
+	# Add-on license such as GPL 2
+	addon_license="GPL-2.0",
+	# URL for the license document the ad-on is licensed under
+	addon_licenseURL="https://www.gnu.org/licenses/gpl-2.0.html",
+)
 
 # Define the python files that are the sources of your add-on.
 # You can either list every file (using ""/") as a path separator,
@@ -54,26 +61,48 @@ For other instructions, press  actions button in add-on store, then go to help."
 # pythonSources = ["addon/globalPlugins/*.py"]
 # For more information on SCons Glob expressions please take a look at:
 # https://scons.org/doc/production/HTML/scons-user/apd.html
-pythonSources = [
+pythonSources: list[str] = [
 	"addon/*.py",
 	"addon/globalPlugins/clock/*.py",
 ]
 
 # Files that contain strings for translation. Usually your python sources
-i18nSources = pythonSources + ["buildVars.py"]
+i18nSources: list[str] = pythonSources + ["buildVars.py"]
 
 # Files that will be ignored when building the nvda-addon file
 # Paths are relative to the addon directory, not to the root directory of your addon sources.
-excludedFiles = []
+# You can either list every file (using ""/") as a path separator,
+# or use glob expressions.
+excludedFiles: list[str] = []
 
 # Base language for the NVDA add-on
 # If your add-on is written in a language other than english, modify this variable.
 # For example, set baseLanguage to "es" if your add-on is primarily written in spanish.
-baseLanguage = "en"
+# You must also edit .gitignore file to specify base language files to be ignored.
+baseLanguage: str = "en"
 
 # Markdown extensions for add-on documentation
 # Most add-ons do not require additional Markdown extensions.
 # If you need to add support for markup such as tables, fill out the below list.
 # Extensions string must be of the form "markdown.extensions.extensionName"
 # e.g. "markdown.extensions.tables" to add tables.
-markdownExtensions = []
+markdownExtensions: list[str] = []
+
+# Custom braille translation tables
+# If your add-on includes custom braille tables (most will not), fill out this dictionary.
+# Each key is a dictionary named according to braille table file name,
+# with keys inside recording the following attributes:
+# displayName (name of the table shown to users and translatable),
+# contracted (contracted (True) or uncontracted (False) braille code),
+# output (shown in output table list),
+# input (shown in input table list).
+brailleTables: BrailleTables = {}
+
+# Custom speech symbol dictionaries
+# Symbol dictionary files reside in the locale folder, e.g. `locale\en`, and are named `symbols-<name>.dic`.
+# If your add-on includes custom speech symbol dictionaries (most will not), fill out this dictionary.
+# Each key is the name of the dictionary,
+# with keys inside recording the following attributes:
+# displayName (name of the speech dictionary shown to users and translatable),
+# mandatory (True when always enabled, False when not.
+symbolDictionaries: SymbolDictionaries = {}

--- a/site_scons/site_tools/NVDATool/__init__.py
+++ b/site_scons/site_tools/NVDATool/__init__.py
@@ -1,0 +1,105 @@
+"""
+This tool generates NVDA extensions.
+
+Builders:
+
+- NVDAAddon: Creates a .nvda-addon zip file. Requires the `excludePatterns` environment variable.
+- NVDAManifest: Creates the manifest.ini file.
+- NVDATranslatedManifest: Creates the manifest.ini file with only translated information.
+- md2html: Build HTML from Markdown
+
+The following environment variables are required to create the manifest:
+
+- addon_info: .typing.AddonInfo
+- brailleTables: .typings.BrailleTables
+- symbolDictionaries: .typings.SymbolDictionaries
+
+The following environment variables are required to build the HTML:
+
+- moFile: str | pathlib.Path | None
+- mdExtensions: list[str]
+- addon_info: .typings.AddonInfo
+
+"""
+
+from SCons.Script import Environment, Builder
+
+from .addon import createAddonBundleFromPath
+from .manifests import generateManifest, generateTranslatedManifest
+from .docs import md2html
+
+
+
+def generate(env: Environment):
+	env.SetDefault(excludePatterns=tuple())
+
+	addonAction = env.Action(
+		lambda target, source, env: createAddonBundleFromPath(
+			source[0].abspath, target[0].abspath, env["excludePatterns"]
+		) and None,
+		lambda target, source, env: f"Generating Addon {target[0]}",
+	)
+	env["BUILDERS"]["NVDAAddon"] = Builder(
+		action=addonAction,
+		suffix=".nvda-addon",
+		src_suffix="/"
+	)
+
+	env.SetDefault(brailleTables={})
+	env.SetDefault(symbolDictionaries={})
+
+	manifestAction = env.Action(
+		lambda target, source, env: generateManifest(
+			source[0].abspath,
+			target[0].abspath,
+			addon_info=env["addon_info"],
+			brailleTables=env["brailleTables"],
+			symbolDictionaries=env["symbolDictionaries"],
+		) and None,
+		lambda target, source, env: f"Generating manifest {target[0]}",
+	)
+	env["BUILDERS"]["NVDAManifest"] = Builder(
+		action=manifestAction,
+		suffix=".ini",
+		src_siffix=".ini.tpl"
+	)
+
+	translatedManifestAction = env.Action(
+		lambda target, source, env: generateTranslatedManifest(
+			source[1].abspath,
+			target[0].abspath,
+			mo=source[0].abspath,
+			addon_info=env["addon_info"],
+			brailleTables=env["brailleTables"],
+			symbolDictionaries=env["symbolDictionaries"],
+		) and None,
+		lambda target, source, env: f"Generating translated manifest {target[0]}",
+	)
+
+	env["BUILDERS"]["NVDATranslatedManifest"] = Builder(
+		action=translatedManifestAction,
+		suffix=".ini",
+		src_siffix=".ini.tpl"
+	)
+
+	env.SetDefault(mdExtensions = {})
+
+	mdAction = env.Action(
+		lambda target, source, env: md2html(
+			source[0].path,
+			target[0].path,
+			moFile=env["moFile"].path if env["moFile"] else None,
+			mdExtensions=env["mdExtensions"],
+			addon_info=env["addon_info"],
+		) and None,
+		lambda target, source, env: f"Generating {target[0]}",
+	)
+	env["BUILDERS"]["md2html"] = env.Builder(
+		action=mdAction,
+		suffix=".html",
+		src_suffix=".md",
+	)
+
+
+def exists():
+	return True

--- a/site_scons/site_tools/NVDATool/addon.py
+++ b/site_scons/site_tools/NVDATool/addon.py
@@ -1,0 +1,24 @@
+import zipfile
+from collections.abc import Iterable
+from pathlib import Path
+
+
+
+def matchesNoPatterns(path: Path, patterns: Iterable[str]) -> bool:
+	"""Checks if the path, the first argument, does not match any of the patterns passed as the second argument."""
+	return not any((path.match(pattern) for pattern in patterns))
+
+
+def createAddonBundleFromPath(path: str | Path, dest: str, excludePatterns: Iterable[str]):
+	"""Creates a bundle from a directory that contains an addon manifest file."""
+	if isinstance(path, str):
+		path = Path(path)
+	basedir = path.absolute()
+	with zipfile.ZipFile(dest, "w", zipfile.ZIP_DEFLATED) as z:
+		for p in basedir.rglob("*"):
+			if p.is_dir():
+				continue
+			pathInBundle = p.relative_to(basedir)
+			if matchesNoPatterns(pathInBundle, excludePatterns):
+				z.write(p, pathInBundle)
+	return dest

--- a/site_scons/site_tools/NVDATool/docs.py
+++ b/site_scons/site_tools/NVDATool/docs.py
@@ -1,0 +1,61 @@
+
+import gettext
+from pathlib import Path
+
+import markdown
+
+from .typings import AddonInfo
+
+
+
+def md2html(
+		source: str | Path,
+		dest: str | Path,
+		*,
+		moFile: str | Path|None,
+		mdExtensions: list[str],
+		addon_info: AddonInfo
+	):
+	if isinstance(source, str):
+		source = Path(source)
+	if isinstance(dest, str):
+		dest = Path(dest)
+	if isinstance(moFile, str):
+		moFile = Path(moFile)
+
+	try:
+		with moFile.open("rb") as f:
+			_ = gettext.GNUTranslations(f).gettext
+	except Exception:
+		summary = addon_info["addon_summary"]
+	else:
+		summary = _(addon_info["addon_summary"])
+	version = addon_info["addon_version"]
+	title = f"{summary} {version}"
+	lang = source.parent.name.replace("_", "-")
+	headerDic = {
+		'[[!meta title="': "# ",
+		'"]]': " #",
+	}
+	with source.open("r", encoding="utf-8") as f:
+		mdText = f.read()
+	for k, v in headerDic.items():
+		mdText = mdText.replace(k, v, 1)
+	htmlText = markdown.markdown(mdText, extensions=mdExtensions)
+	# Optimization: build resulting HTML text in one go instead of writing parts separately.
+	docText = "\n".join(
+		(
+			"<!DOCTYPE html>",
+			f'<html lang="{lang}">',
+			"<head>",
+			'<meta charset="UTF-8">',
+			'<meta name="viewport" content="width=device-width, initial-scale=1.0">',
+			'<link rel="stylesheet" type="text/css" href="../style.css" media="screen">',
+			f"<title>{title}</title>",
+			"</head>\n<body>",
+			htmlText,
+			"</body>\n</html>",
+		)
+	)
+	with dest.open("w", encoding="utf-8") as f:
+		f.write(docText) # type: ignore

--- a/site_scons/site_tools/NVDATool/manifests.py
+++ b/site_scons/site_tools/NVDATool/manifests.py
@@ -1,0 +1,69 @@
+
+import codecs
+import gettext
+from functools import partial
+
+from .typings import AddonInfo, BrailleTables, SymbolDictionaries
+from .utils import format_nested_section
+
+
+
+def generateManifest(
+		source: str,
+		dest: str,
+		addon_info: AddonInfo,
+		brailleTables: BrailleTables,
+		symbolDictionaries: SymbolDictionaries,
+	):
+	# Prepare the root manifest section
+	with codecs.open(source, "r", "utf-8") as f:
+		manifest_template = f.read()
+	manifest = manifest_template.format(**addon_info)
+	# Add additional manifest sections such as custom braile tables
+	# Custom braille translation tables
+	if brailleTables:
+		manifest += format_nested_section("brailleTables", brailleTables)
+
+	# Custom speech symbol dictionaries
+	if symbolDictionaries:
+		manifest += format_nested_section("symbolDictionaries", symbolDictionaries)
+
+	with codecs.open(dest, "w", "utf-8") as f:
+		f.write(manifest)
+
+
+def generateTranslatedManifest(
+		source: str,
+		dest: str,
+		*,
+		mo: str,
+		addon_info: AddonInfo,
+		brailleTables: BrailleTables,
+		symbolDictionaries: SymbolDictionaries,
+	):
+	with open(mo, "rb") as f:
+		_ = gettext.GNUTranslations(f).gettext
+	vars: dict[str, str] = {}
+	for var in ("addon_summary", "addon_description", "addon_changelog"):
+		vars[var] = _(addon_info[var])
+	with codecs.open(source, "r", "utf-8") as f:
+		manifest_template = f.read()
+	manifest = manifest_template.format(**vars)
+
+	_format_section_only_with_displayName = partial(
+		format_nested_section,
+		include_only_keys = ("displayName",),
+		_ = _,
+	)
+
+	# Add additional manifest sections such as custom braile tables
+	# Custom braille translation tables
+	if brailleTables:
+		manifest += _format_section_only_with_displayName("brailleTables", brailleTables)
+
+	# Custom speech symbol dictionaries
+	if symbolDictionaries:
+		manifest += _format_section_only_with_displayName("symbolDictionaries", symbolDictionaries)
+
+	with codecs.open(dest, "w", "utf-8") as f:
+		f.write(manifest)

--- a/site_scons/site_tools/NVDATool/typings.py
+++ b/site_scons/site_tools/NVDATool/typings.py
@@ -1,0 +1,39 @@
+from typing import TypedDict, Protocol
+
+
+
+class AddonInfo(TypedDict):
+	addon_name: str
+	addon_summary: str
+	addon_description: str
+	addon_version: str
+	addon_changelog: str
+	addon_author: str
+	addon_url: str | None
+	addon_sourceURL: str | None
+	addon_docFileName: str
+	addon_minimumNVDAVersion: str | None
+	addon_lastTestedNVDAVersion: str | None
+	addon_updateChannel: str | None
+	addon_license: str | None
+	addon_licenseURL: str | None
+
+
+class BrailleTableAttributes(TypedDict):
+    displayName: str
+    contracted: bool
+    output: bool
+    input: bool
+
+
+class SymbolDictionaryAttributes(TypedDict):
+    displayName: str
+    mandatory: bool
+
+
+BrailleTables = dict[str, BrailleTableAttributes]
+SymbolDictionaries = dict[str, SymbolDictionaryAttributes]
+
+
+class Strable(Protocol):
+	def __str__(self) -> str: ...

--- a/site_scons/site_tools/NVDATool/utils.py
+++ b/site_scons/site_tools/NVDATool/utils.py
@@ -1,0 +1,28 @@
+from collections.abc import Callable, Container, Mapping
+
+from .typings import Strable
+
+
+
+def _(arg: str) -> str:
+	"""
+	A function that passes the string to it without doing anything to it.
+	Needed for recognizing strings for translation by Gettext.
+	"""
+	return arg
+
+
+def format_nested_section(
+	section_name: str,
+	data: Mapping[str, Mapping[str, Strable]],
+	include_only_keys: Container[str] | None = None,
+	_: Callable[[str], str] = _,
+) -> str:
+	lines = [f"\n[{section_name}]"]
+	for item_name, inner_dict in data.items():
+		lines.append(f"[[{item_name}]]")
+		for key, val in inner_dict.items():
+			if include_only_keys and key not in include_only_keys:
+				continue
+			lines.append(f"{key} = {_(str(val))}")
+	return "\n".join(lines) + "\n"

--- a/site_scons/site_tools/gettexttool/__init__.py
+++ b/site_scons/site_tools/gettexttool/__init__.py
@@ -1,4 +1,4 @@
-""" This tool allows generation of gettext .mo compiled files, pot files from source code files
+"""This tool allows generation of gettext .mo compiled files, pot files from source code files
 and pot files for merging.
 
 Three new builders are added into the constructed environment:
@@ -15,6 +15,7 @@ To properly configure get text, define the following variables:
 
 
 """
+
 from SCons.Action import Action
 
 
@@ -36,20 +37,19 @@ def generate(env):
 	env.SetDefault(gettext_package_name="")
 	env.SetDefault(gettext_package_version="")
 
-	env['BUILDERS']['gettextMoFile'] = env.Builder(
+	env["BUILDERS"]["gettextMoFile"] = env.Builder(
 		action=Action("msgfmt -o $TARGET $SOURCE", "Compiling translation $SOURCE"),
 		suffix=".mo",
-		src_suffix=".po"
+		src_suffix=".po",
 	)
 
-	env['BUILDERS']['gettextPotFile'] = env.Builder(
-		action=Action("xgettext " + XGETTEXT_COMMON_ARGS, "Generating pot file $TARGET"),
-		suffix=".pot")
+	env["BUILDERS"]["gettextPotFile"] = env.Builder(
+		action=Action("xgettext " + XGETTEXT_COMMON_ARGS, "Generating pot file $TARGET"), suffix=".pot"
+	)
 
-	env['BUILDERS']['gettextMergePotFile'] = env.Builder(
+	env["BUILDERS"]["gettextMergePotFile"] = env.Builder(
 		action=Action(
-			"xgettext " + "--omit-header --no-location " + XGETTEXT_COMMON_ARGS,
-			"Generating pot file $TARGET"
+			"xgettext " + "--omit-header --no-location " + XGETTEXT_COMMON_ARGS, "Generating pot file $TARGET"
 		),
-		suffix=".pot"
+		suffix=".pot",
 	)


### PR DESCRIPTION
This pull request updates the Clock add-on to support NVDA 2026.1. All deprecated or removed APIs have been replaced with their current equivalents to ensure compatibility and stability.



\#### Key Changes:

Migrated from deprecated `none` constant to `0`, aligning with updated NVDA core definitions.

Replaced all removed or outdated functions with their modern counterparts.

Cleaned up legacy references and ensured the add-on builds and runs smoothly under NVDA 2026.1.



