### PR TITLE
Simplify Crowdin translation synchronization workflow

### DIFF
--- a/.github/scripts/crowdinSync.ps1
+++ b/.github/scripts/crowdinSync.ps1
@@ -53,7 +53,6 @@ if (Test-Path $xliffFile) {
     git diff --staged --quiet
     if ($LASTEXITCODE -ne 0) {
         git commit -m "Update $xliffFile for $addonId"
-        git push
     }
 }
 
@@ -172,9 +171,22 @@ git add addon/locale addon/doc
 git diff --staged --quiet
 if ($LASTEXITCODE -ne 0) {
     git commit -m "Update translations for $addonId from Crowdin (Automatic Sync)"
-    $branch = $env:downloadTranslationsBranch
-    git push -f origin "HEAD:$branch"
-    Write-Host "SUCCESS: Translations committed and pushed."
+    Write-Host "SUCCESS: Translations committed."
 } else {
     Write-Host "DEBUG: No changes in translations to commit."
+}
+
+# Push all generated commits after successful Crowdin synchronization
+$pushOutput = git push 2>&1
+
+Write-Host $pushOutput
+
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "ERROR: Failed to push commits to $repository."
+}
+elseif ($pushOutput -match "Everything up-to-date") {
+    Write-Host "INFO: No new commits needed to be pushed."
+}
+else {
+    Write-Host "SUCCESS: New commits successfully pushed to $repository."
 }

--- a/.github/workflows/crowdinL10n.yml
+++ b/.github/workflows/crowdinL10n.yml
@@ -12,7 +12,6 @@ concurrency:
 
 env:
   crowdinAuthToken: ${{ secrets.CROWDIN_TOKEN }}
-  downloadTranslationsBranch: l10n
   GH_TOKEN: ${{ github.token }}
   CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID || 780748 }}
   L10N_UTIL_CONFIG: ${{ vars.L10N_UTIL_CONFIG || 'addon' }}


### PR DESCRIPTION
### Simplify Crowdin translation synchronization workflow

This PR simplifies the translation synchronization workflow used by Crowdin integration.

#### Changes included

* Remove the dedicated `l10n` branch handling previously used during translation synchronization.
* Push translation updates directly to the workflow branch currently checked out by GitHub Actions.
* Remove the obsolete `downloadTranslationsBranch` workflow environment variable.
* Replace multiple intermediate `git push` operations with a single final push performed after all commits have been created.

#### Why this change is needed

The previous implementation pushed the final translation synchronization commit to a dedicated `l10n` branch instead of the active workflow branch.

As a result:

* only the first generated commit was immediately visible on the workflow branch;
* the final translation update commit was pushed elsewhere;
* and repository states could temporarily appear inconsistent during workflow execution.

This new approach keeps the complete synchronization process on the current workflow branch and avoids intermediate repository states by performing a single final `git push`.

#### Expected benefits

* Simpler and more predictable synchronization behavior.
* Cleaner workflow execution.
* Easier debugging and repository maintenance.
* Reduced confusion for add-on maintainers consuming translation updates.
This removes the dedicated l10n branch handling previously used during translation synchronization.

Translation updates are now pushed directly to the branch checked out by the workflow instead of being force-pushed to l10n.

Also removes the obsolete downloadTranslationsBranch workflow environment variable, which is no longer needed.

Additionally, translation synchronization now performs a single final git push after all commits have been created, avoiding intermediate repository states during workflow execution.